### PR TITLE
Only import the git module locally

### DIFF
--- a/torchbeast/core/file_writer.py
+++ b/torchbeast/core/file_writer.py
@@ -22,22 +22,26 @@ import os
 import time
 from typing import Dict
 
-import git
 
 
 def gather_metadata() -> Dict:
     date_start = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")
     # Gathering git metadata.
     try:
-        repo = git.Repo(search_parent_directories=True)
-        git_sha = repo.commit().hexsha
-        git_data = dict(
-            commit=git_sha,
-            branch=None if repo.head.is_detached else repo.active_branch.name,
-            is_dirty=repo.is_dirty(),
-            path=repo.git_dir,
-        )
-    except git.InvalidGitRepositoryError:
+        import git
+
+        try:
+            repo = git.Repo(search_parent_directories=True)
+            git_sha = repo.commit().hexsha
+            git_data = dict(
+                commit=git_sha,
+                branch=None if repo.head.is_detached else repo.active_branch.name,
+                is_dirty=repo.is_dirty(),
+                path=repo.git_dir,
+            )
+        except git.InvalidGitRepositoryError:
+            git_data = None
+    except ImportError:
         git_data = None
     # Gathering slurm metadata.
     if "SLURM_JOB_ID" in os.environ:


### PR DESCRIPTION
Some systems (e.g. nodes in HPC clusters) don't have git installed on them.