### PR TITLE
Don't require Python 3.7 EXACT in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 # ##############################################################################
 # Declare dependencies
 find_package(Threads REQUIRED)
-find_package(Python3 3.7 EXACT COMPONENTS Interpreter Development NumPy)
+find_package(Python3 3.7 COMPONENTS Interpreter Development NumPy)
 
 # Make sure we are compatible with torch ABI. Must go before any
 # add_subdirectory.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To set it up, create a new conda environment and install MonoBeast's
 requirements:
 
 ```bash
-$ conda create -n torchbeast python=3.7
+$ conda create -n torchbeast
 $ conda activate torchbeast
 $ conda install pytorch -c pytorch
 $ pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ To run PolyBeast directly on Linux or MacOS, follow this guide.
 Create a new Conda environment, and install PolyBeast's requirements:
 
 ```shell
-$ conda create -n torchbeast
+$ conda create -n torchbeast python=3.7
 $ conda activate torchbeast
 $ pip install -r requirements.txt
 ```


### PR DESCRIPTION
Based on my unsuccsessful attempt to build PolyBeast in a Python 3.8 environment, I understand that something explicitly requires 3.7. If my understanding is correct, could you please update PolyBeast installation instructions accordingly?